### PR TITLE
Update ship2.json

### DIFF
--- a/setup/ship2.json
+++ b/setup/ship2.json
@@ -3,7 +3,7 @@
    "name":"JENS SØRENSEN",
    "attributes":[
       {
-         "attributeName":"IMO number",
+         "attributeName":"IMO-number",
          "attributeValue":"9080950"
       },
       {


### PR DESCRIPTION
Before, when trying to add this vessel, I would get this error message:
`{"timestamp":1563362181606,"status":400,"error":"Bad Request","message":"attributeName value is invalid","path":"/x509/api/org/urn:mrn:mcl:org:dma/vessel"}`

By replacing "IMO number" with "IMO-number", the problem is no longer there